### PR TITLE
Added Farmazia Hiztegia

### DIFF
--- a/src/chrome/content/dicts.js
+++ b/src/chrome/content/dicts.js
@@ -56,6 +56,7 @@ euskalbar.dicts = function () {
       'eurovoc',
       'euskal_klasikoak',
       'euskalterm',
+      'farmazia',
       'goihata',
       'harluxet',
       'hautalan',

--- a/src/chrome/content/dicts/farmazia.js
+++ b/src/chrome/content/dicts/farmazia.js
@@ -1,0 +1,54 @@
+/*
+ * Euskalbar - A Firefox extension for helping in Basque translations.
+ * Copyright (C) 2015 Euskalbar Taldea (see AUTHORS file)
+ *
+ * This file is part of Euskalbar.
+ *
+ * Euskalbar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+if (!euskalbar) var euskalbar = {};
+
+if (!euskalbar.dicts) euskalbar.dicts = {};
+
+euskalbar.dicts.farmazia = function () {
+
+  return {
+    displayName: 'Farmazia',
+    description: 'Farmazia hiztegia',
+
+    homePage: 'http://www.feuse.info/hiztegia/',
+
+    pairs: ['eu-es', 'es-eu'],
+
+    method: 'POST',
+
+    mimeType: "text/html; charset=UTF-8",
+
+    getUrl: function (opts) {
+      return 'http://www.feuse.info/hiztegia/index.php';
+    },
+
+    getParams: function (opts) {
+      return {
+        'data': opts.term,
+        'sailkapena': ''
+      };
+    }
+
+  };
+
+}();


### PR DESCRIPTION
Farmazia Hiztegia gehitu dut.
http://www.feuse.info/hiztegia/

Funtzionatzen du baina gaztelerazko azentudun hitzekin arazoak ematen ditu, adibidez, 'fármaco' hitzarekin.

MIME mota desberdinak erabiliz proba batzuk egin ditut:

* mimeType: "text/html; charset=ISO-8859-1"
  * fármaco bilatuta -> Bilatutako testua ondo agertzen da baina ez du bilaketarik egiten. Bilatu botoia sakatuz gero emaitzak ondo agertzen dira, adibidez, psicofármaco.
  * farmaco bilatuta -> Bilaketa egiten du baina emaitzetan karaktere batzuk ez dira ondo ikusten, adibidez, psicofÃ¡rmaco

* mimeType: "text/html; charset=UTF-8"
  * fármaco bilatuta -> Bilatutako testua gaizki agertzen da (fÃ¡rmaco) baina bilaketa ondo egiten du. Bilaketaren emaitzetan karaktere batzuk ez dira ondo ikusten, adibidez, psicofÃ¡rmaco
  * farmaco bilatuta -> Bilaketa ondo egiten du baina emaitzetan karaktere batzuk ez dira ondo ikusten, adibidez, psicofÃ¡rmaco

UTF-8 bezala utzi dut, gutxienez bilaketa egiten duelako baina ez naiz oso gustura geratu. Konponbiderik ikusten diozue?