### PR TITLE
Fix autofocus in Chrome adding a tabindex

### DIFF
--- a/src/euskalbar.html
+++ b/src/euskalbar.html
@@ -43,7 +43,7 @@
                 <option value="zh-eu">ZH &rarr; EU</option>
             </select>
 
-            <input type="text" id="BilatzekoaText" />          
+            <input type="text" id="BilatzekoaText" tabindex="1" autofocus />          
 
         </form> 
 	<p class="estekak">

--- a/src/js/euskalbar.js
+++ b/src/js/euskalbar.js
@@ -937,10 +937,9 @@ document.addEventListener('DOMContentLoaded',function()
     BistaratuBotoiak();
 
     // Kutxan tekla sakatzen denean, Enter den begiratu
-
     document.getElementById('BilatzekoaText').addEventListener('keypress',BaliabideakIrekiEnter);
-
-    // Hizkuntza bikotea aldatzen denean, gorde hurrengorako
+    
+	// Hizkuntza bikotea aldatzen denean, gorde hurrengorako
 
     document.getElementById("HizkuntzaBikoteaSelect").addEventListener('change',function()
     {


### PR DESCRIPTION
5.0 version has code for focusing in search textfield but it is not working (nor in Firefox neither in Chrome). This commit fixes the autofocus issue in Chrome (Firefox should also obey the standard way for autofocusing - using autofocus property in html5 or at least when using focus() from JS, but it isn't :( ) The tabindex="1" trick makes the difference in Chrome.